### PR TITLE
Remove 'enablePgdbi'

### DIFF
--- a/bin/pgdbi/index.js
+++ b/bin/pgdbi/index.js
@@ -44,10 +44,7 @@ let pgdbiApp;
 
 module.exports = {
   'postgraphile:options'(options, {pgPool}) {
-    if (options.enablePgdbi) {
-      // Create our app
-      pgdbiApp = PostgraphileDE(options, pgPool)
-    }
+    pgdbiApp = PostgraphileDE(options, pgPool)
 
     // Must always return from a hook function
     return options;

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "license": "MIT",
   "scripts": {
     "dev-server": "nodemon src/devServer",
-    "dev-web-vue": "cd ./src/web-vue & yarn serve",
-    "prod-build": "cd ./src/web-vue & yarn build"
+    "dev-web-vue": "cd ./src/web-vue && yarn serve",
+    "prod-build": "cd ./src/web-vue && yarn build"
   },
   "dependencies": {
     "express": "^4.16.4",

--- a/readme.md
+++ b/readme.md
@@ -1,31 +1,39 @@
 # postgraphile-db-inspector-extension
 
+
+## Installation
+
 ```
 yarn add postgraphile-db-inspector-extension
 ```
 
-Use as a server plugin; e.g.
+## Usage
+
+Currently recommended for development only; to disable in production, do not
+load this plugin.
+
+This is a [PostGraphile Server Plugin](https://www.graphile.org/postgraphile/plugins/) so you can follow the standard server plugin instructions, namely:
+
+For the CLI, use `--plugins` to load the plugin (and remember this flag must come at the very start!)
 
 ```
 postgraphile --plugins postgraphile-db-inspector-extensions -c my_db
 ```
 
-or
+For PostGraphile as a library/middleware, you must use the plugin hook functionality:
 
-```
+```js
 const pgdbi = require('postgraphile-db-inspector-extension')
-const {postgraphile, makePluginHook} = require("postgraphile");
-const pluginHook = makePluginHook([pgdbi]);
+const { postgraphile, makePluginHook } = require("postgraphile");
+
+const pluginHook = makePluginHook([
+  pgdbi,
+  /* other server plugins can be added here */
+]);
 
 app.use(postgraphile(connectionString, schemas, {
   pluginHook,
-  enablePgdbi: true
 }))
-```
-
-In library mode you must enable pgdbi in PostGraphile options:
-```
-enablePgdbi: true,
 ```
 
 You can access pgdbi at the `/pgdbi` sub path, e.g. [http://localhost:5000/pgdbi](http://localhost:5000/pgdbi).

--- a/src/devServer/index.js
+++ b/src/devServer/index.js
@@ -6,9 +6,6 @@ try {
 const express = require("express");
 const {postgraphile, makePluginHook} = require("postgraphile");
 
-const pluginHook = makePluginHook([
-  require('../pgdbi')
-])
 const plugins = [
   // require('postgraphile-plugin-connection-filter'),
 ]
@@ -29,6 +26,8 @@ if (!POSTGRES_CONNECTION) {
   throw new Error("No 'POSTGRES_CONNECTION' envvar found, we don't know which database to connect to.");
 }
 
+const identity = _ => _;
+
 
 const port = PORT;
 const connection = POSTGRES_CONNECTION;
@@ -37,6 +36,10 @@ const dynamicJson = DYNAMIC_JSON === 'true';
 const disableDefaultMutations = DISABLE_DEFAULT_MUTATIONS === 'true';
 const watchPg = WATCH_PG === 'true';
 const enablePgdbi = ENABLE_PGDBI === 'true';
+
+const pluginHook = makePluginHook([
+  enablePgdbi ? require('../pgdbi') : null
+].filter(identity))
 
 const app = express();
 
@@ -52,7 +55,6 @@ app.use(postgraphile(
     ,appendPlugins: plugins
     ,watchPg: watchPg
     ,graphiql: true
-    ,enablePgdbi
   }
 ));
 

--- a/src/pgdbi/index.js
+++ b/src/pgdbi/index.js
@@ -44,10 +44,8 @@ let pgdbiApp;
 
 module.exports = {
   'postgraphile:options'(options, {pgPool}) {
-    if (options.enablePgdbi) {
-      // Create our app
-      pgdbiApp = PostgraphileDE(options, pgPool)
-    }
+    // Create our app
+    pgdbiApp = PostgraphileDE(options, pgPool)
 
     // Must always return from a hook function
     return options;


### PR DESCRIPTION
If you load the plugin but disable it then every HTTP request will still have to call the hook before seeing there's nothing to do. It's better to not load it in the first place, and less options for users to understand.