### PR TITLE
Rename npm module to '@graphile-contrib/pgdbi'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "postgraphile-db-inspector-extension",
+  "name": "@graphile-contrib/pgdbi",
   "version": "1.0.9-alpha.46",
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/stlbucket/postgraphile-db-inspector-extension"
+    "url": "https://github.com/graphile-contrib/pgdbi"
   },
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
I need to publish the first version, but after that I can delegate publish permissions to you. Would you rather keep the current name, or rename?